### PR TITLE
bugfix: initializing allocated memory for ISR functions

### DIFF
--- a/nano.c
+++ b/nano.c
@@ -693,7 +693,7 @@ int gpioInitialise(void){
 
   // Allocating memory for the struct
   for (int j = 0; j < 41; j++) {
-    ISRFunc_CFG[j] = malloc (sizeof(ISRFunc));
+    ISRFunc_CFG[j] = calloc (1, sizeof(ISRFunc));
   }
   return status;
 }

--- a/orin.c
+++ b/orin.c
@@ -738,7 +738,7 @@ int gpioInitialise(void)
 
   // Allocating memory for the struct
   for (int j = 0; j < 41; j++) {
-    ISRFunc_CFG[j] = malloc (sizeof(ISRFunc));
+    ISRFunc_CFG[j] = calloc (1, sizeof(ISRFunc));
   }
   return status;
 }


### PR DESCRIPTION
Allocating dynamic memory for ISR functions using `malloc()` leaves that memory uninitialized. This causes latter code to perform conditional jumps on uninitialized values.

Output produced while debugging with `valgrind`:
```
Conditional jump or move depends on uninitialised value(s)
    at 0x48A8C74: gpioSetISRFunc (orin.c:2044)
    ...
```
The code that does the conditional jump on an uninitialized value:
```c
if (ISRFunc_CFG[gpio]->gpio != 0) {
    // ...
}
```

The proposed solution simply uses `calloc()` instead of `malloc()`. This causes all the allocated memory to be initialized to 0.