### PR TITLE
New makefile target installs the library without Jetclocks.

### DIFF
--- a/makefile
+++ b/makefile
@@ -40,6 +40,19 @@ step4:
 		systemctl start pwm_enable.service;\
 	fi
 
+step4_no_jetclocks:
+	install -m 0755 $(LIB) /usr/lib
+	install -m 0644 jetgpio.h /usr/include
+	ldconfig
+	ldconfig -p | grep libjetgpio.so
+	@if  [ $(MODEL) = "xavier" ]; then\
+                cp ./scripts/pwm_enabler.sh /etc/systemd/system;\
+                cp ./scripts/pwm_enable.service /etc/systemd/system;\
+                chmod +x /etc/systemd/system/pwm_enabler.sh;\
+                chown root /etc/systemd/system/pwm_enabler.sh;\
+                systemctl enable pwm_enable.service;\
+                systemctl start pwm_enable.service;\
+        fi
 
 step5:
 	$(eval MODEL := $(shell find /lib/modules/$(uname -r) -name "jetclocks.ko" -exec basename {} \;))
@@ -80,6 +93,8 @@ clean:
 	rm -f *.o $(LIB) get_chip_id hardware
 
 install: step2 step4
+
+install-no-jetclocks: step2 step4_no_jetclocks
 
 uninstall: step5 step6
 


### PR DESCRIPTION
According to JETGPIO's readme:

> The following applies to the Orin family only. This version of the library installs and works along a kernel module: [Jetclocks](https://github.com/Rubberazer/Jetclocks). This provides extra functionality but the automatic installation process could clash with other tools that also perform automatic updates of the device tree, such as the famous jetson-io.py.

This PR adds a new `install-no-jetclocks` target to the makefile that installs the library without the Jetclocks dependency. This target lets Orin users avoid the aforementioned device tree problems at the cost of losing the pwm and extPeripheral* functionalities, which are those that depend on the clocks exposed by Jetclocks on user space.